### PR TITLE
Update checkout+setup actions and add additional input `test-command`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Shared Github Actions for ioBroker testing workflows: Check and lint step
 | `type-checking-command` | Overwrite the default type checking command                                                                                                                                                          | ❌        | `'npm run check'` |
 | `lint`                  | Set to `'true'` when the adapter has a linter configured                                                                                                                                             | ❌        |     `'false'`     |
 | `lint-command`          | Overwrite the default lint command                                                                                                                                                                   | ❌        | `'npm run lint'`  |
+| `test-command`          | Overwrite the default test command                                                                                                                                                                   | ❌        | `'npm run test:package'`  |
+
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'ioBroker Testing: check and lint'
 author: 'AlCalzone'
-#description: 'Greet someone'
+description: 'Perform type checking, linting and testing of an ioBroker adapter package'
 
 inputs:
   node-version:
@@ -24,15 +24,18 @@ inputs:
   lint-command: 
     description: 'Overwrite the default lint command'
     default: 'npm run lint'
+  test-command:
+    description: 'Overwrite the default test command'
+    default: 'npm run test:package' 
 
 runs:
   using: "composite"
   steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Use Node.js ${{ inputs.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ (inputs.package-cache != 'false' && inputs.package-cache != '') && inputs.package-cache || '' }}
@@ -61,4 +64,4 @@ runs:
 
     - name: Test package files
       shell: bash
-      run: npm run test:package
+      run: "${{ inputs.test-command }}"


### PR DESCRIPTION
I have forked this repo to get rid of the warnings in my iobroker adapter workflow actions regarding the usage of the outdated `actions/checkout@v3` and `actions/setup-node@v3`.
The additional `test-command` parameter might not be necessary, but I saw no reason to not overwrite it with the appropriate yarn call...

Maybe you want to add the parameter and foreign actions update in your official implementation as well. 🤷‍♂️ 